### PR TITLE
v1.4.1

### DIFF
--- a/WES.config
+++ b/WES.config
@@ -300,7 +300,7 @@ process {
     }
 
     withLabel: VERIFYBAMID_2_0_1_h32f71e1_2_VerifyBamID2 {
-        cpus = 1
+        cpus = 2
         memory = '5G'
         time = '1h'
 

--- a/WES.config
+++ b/WES.config
@@ -348,6 +348,9 @@ profiles {
 
         executor {
             queueSize = 1000
+            pollInterval = '1min'
+            queueStatInterval = '5min'
+            submitRatelimit = '10sec'
         }
     }
 


### PR DESCRIPTION
Update WES.config
- Executor settings, request from UMCU HPC admins to reduce the load on the slurm scheduler. 
- Set VerifyBamID2 cpus = 2. This will make sure we request a 'complete' cpu core on our HPC system instead of one (hyper)thread.