### PR TITLE
Enable javamail module by configuring smtp host.

### DIFF
--- a/WES.config
+++ b/WES.config
@@ -371,6 +371,10 @@ profiles {
             queueStatInterval = '5min'
             submitRatelimit = '10sec'
         }
+ 
+       mail {
+            smtp.host = 'localhost'
+        }
     }
 
     mac {


### PR DESCRIPTION
Part two, solves bug that causes 'error 3' in Azure ID: 113153. By setting smtp.host in settings, we force nextflow to use the javaMail module instead of (apparently buggy) command line tools.