### PR TITLE
Override Nextflow params via optional params

### DIFF
--- a/WES.config
+++ b/WES.config
@@ -20,16 +20,16 @@ params {
 
     clarity_epp_path = '/hpc/diaggen/software/production/clarity_epp'
 
-    exomedepth_path= '/hpc/diaggen/software/production/Dx_resources/ExomeDepth/'
+    exomedepth_path = '/hpc/diaggen/software/production/Dx_resources/ExomeDepth/'
 
     picard_bait = 'Tracks/SureSelect_v7_elidS31285117_Covered.list'
     picard_target = 'Tracks/ENSEMBL_UCSC_merged_collapsed_sorted_v3_20bpflank.list'
 
     // following resources are inside the VerifyBamID2 container (quay.io/biocontainers/verifybamid2:2.0.1--h32f71e1_2).
-    contamination_path_prefix='/usr/local/share/verifybamid2-2.0.1-2/resource/exome/1000g.phase3.10k.b37.exome.vcf.gz.dat'
-    contamination_sites_ud='/usr/local/share/verifybamid2-2.0.1-2/resource/exome/1000g.phase3.10k.b37.exome.vcf.gz.dat.UD'
-    contamination_sites_mu='/usr/local/share/verifybamid2-2.0.1-2/resource/exome/1000g.phase3.10k.b37.exome.vcf.gz.dat.mu'
-    contamination_sites_bed='/usr/local/share/verifybamid2-2.0.1-2/resource/exome/1000g.phase3.10k.b37.exome.vcf.gz.dat.bed'
+    contamination_path_prefix = '/usr/local/share/verifybamid2-2.0.1-2/resource/exome/1000g.phase3.10k.b37.exome.vcf.gz.dat'
+    contamination_sites_ud = '/usr/local/share/verifybamid2-2.0.1-2/resource/exome/1000g.phase3.10k.b37.exome.vcf.gz.dat.UD'
+    contamination_sites_mu = '/usr/local/share/verifybamid2-2.0.1-2/resource/exome/1000g.phase3.10k.b37.exome.vcf.gz.dat.mu'
+    contamination_sites_bed = '/usr/local/share/verifybamid2-2.0.1-2/resource/exome/1000g.phase3.10k.b37.exome.vcf.gz.dat.bed'
 
     vcftools_path = '/hpc/local/CentOS7/cog_bioinf/vcftools-0.1.14/bin'
     plink_path = '/hpc/local/CentOS7/cog_bioinf/plink_1.9b3/'

--- a/run_nextflow_wes.sh
+++ b/run_nextflow_wes.sh
@@ -38,7 +38,7 @@ module load Java/1.8.0_60
 --email $email \
 -profile slurm \
 -resume -ansi-log false \
-${optional_params:-""}
+${optional_params[@]:-""}
 
 if [ \$? -eq 0 ]; then
     echo "Nextflow done."

--- a/run_nextflow_wes.sh
+++ b/run_nextflow_wes.sh
@@ -7,8 +7,8 @@ workflow_path='/hpc/diaggen/software/production/DxNextflowWES'
 input=`realpath -e $1`
 output=`realpath $2`
 email=$3
-
 optional_params=( "${@:4}" )
+
 mkdir -p $output && cd $output
 mkdir -p log
 

--- a/run_nextflow_wes.sh
+++ b/run_nextflow_wes.sh
@@ -8,6 +8,7 @@ input=`realpath -e $1`
 output=`realpath $2`
 email=$3
 
+optional_params=( "${@:4}" )
 mkdir -p $output && cd $output
 mkdir -p log
 
@@ -36,7 +37,8 @@ module load Java/1.8.0_60
 --outdir $output \
 --email $email \
 -profile slurm \
--resume -ansi-log false
+-resume -ansi-log false \
+${optional_params:-""}
 
 if [ \$? -eq 0 ]; then
     echo "Nextflow done."


### PR DESCRIPTION
### What has changed?

1. Possibility to override Nextflow parameters. 
2. Format change: added spaces around `=` in WES.config

Example of command:
`/hpc/diaggen/software/production/DxNextflowWES/run_nextflow_wes.sh /hpc/diaggen/data/raw/<machine>/<runID>/Data/Intensities/BaseCalls/<projectname_and_id> /hpc/diaggen/data/processed/exomes/<runID_projectid> bioinformatica-genetica@umcutrecht.nl "--ped_folder /home/cog/edejong2/" "--trend_analysis_path /hpc/diaggen/software/development/trend_analysis_tool"`


### Additional information

- Multiple parameters are allowed. I suspect the only limit is the number of characters allowed on the command line.
- A parameter is always a pair of the parameter key and value, should be between double quotes and space separated.
- Also possible to use other nextflow run options. Limitation: what is supported in Nextflow.
  - At the moment, providing process resources to override the config is not supported by Nextflow. If it was, or if default process resource is not part of config, you can provide it via: `-process.key=value`.  For more details/information, see [Azure PBI 109147](https://dev.azure.com/umcu/LAB-Bioinformatics-Genetics/_workitems/edit/109147 )
