### PR TITLE
CheckQC settings: add message to output (kinship and gendercheck)

### DIFF
--- a/assets/checkqc_settings.yaml
+++ b/assets/checkqc_settings.yaml
@@ -18,7 +18,7 @@ metrics:
     threshold: "FAIL"
     operator: "=="
     # special report_cols '@all' to select all columns.
-    report_cols: "@all"
+    report_cols: ["message"]
     sample_cols: ["sample_1", "sample_2"]
     comment: "#"
     title: "Kinship"
@@ -26,6 +26,6 @@ metrics:
     qc_col: "status"
     threshold: "FAIL"
     operator: "=="
-    report_cols: ["sample_id", "test_gender", "true_gender"]
+    report_cols: ["sample_id", "message"]
     sample_cols: ["sample_id"]
     title: "GenderCheck"


### PR DESCRIPTION
### What has changed?
Changed the `report_cols` settings of CheckQC for tasks kinship and gendercheck. 
This change requires CustomModules features:

- https://github.com/UMCUGenetics/CustomModules/pull/43
- https://github.com/UMCUGenetics/CustomModules/pull/47

### Examples
Test output:
```
cat /hpc/diaggen/software/development/DxNextflowWES_edit_msg/work/2d/128d12644de7a5fd2dc789363b14a2/20240909_0096_8_test_ellen_summary.csv
cat /hpc/diaggen/software/development/DxNextflowWES_edit_msg/work/9d/042552a556ef57e62223c4c155ef51/20240909_0096_8_test_ellen_summary.csv 
```